### PR TITLE
Bug fixes: Fixed bug on save workout

### DIFF
--- a/lib/features/weight_training_log/presentation/screens/weightlifting_page.dart
+++ b/lib/features/weight_training_log/presentation/screens/weightlifting_page.dart
@@ -103,6 +103,19 @@ class _WeightliftingPageState extends State<WeightliftingPage> {
       return;
     }
 
+    // Check if any exercise has no sets
+    for (final exercise in exercises) {
+      if (exercise.sets.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${exercise.name} has no sets. Add at least one set to each exercise.'),
+            backgroundColor: Colors.red,
+          )
+        );
+        return;
+      }
+    }
+
     setState(() => _isSaving = true);
     
     try {
@@ -239,7 +252,7 @@ class _WeightliftingPageState extends State<WeightliftingPage> {
       backgroundColor: primaryYellow,
       appBar: _buildAppBar(),
       body: _buildBody(),
-      bottomNavigationBar: exercises.isNotEmpty ? _buildBottomBar() : null,
+      bottomNavigationBar: exercises.isNotEmpty && calculateTotalVolume(exercises) > 0 ? _buildBottomBar() : null,
     );
   }
 

--- a/test/features/weight_training_log/presentation/screens/weightlifting_page_test.dart
+++ b/test/features/weight_training_log/presentation/screens/weightlifting_page_test.dart
@@ -7,6 +7,7 @@ import 'package:pockeat/features/weight_training_log/presentation/screens/weight
 import 'package:pockeat/features/weight_training_log/presentation/widgets/exercise_card.dart';
 import 'package:pockeat/features/weight_training_log/presentation/widgets/body_part_chip.dart';
 import 'package:pockeat/features/weight_training_log/domain/models/weight_lifting.dart';
+import 'package:pockeat/features/weight_training_log/presentation/widgets/bottom_bar.dart';
 
 // Import the generated mock file
 import 'weightlifting_page_test.mocks.dart';
@@ -864,6 +865,57 @@ void main() {
       expect(find.text('Testing Weight=50.0, Reps=10, Duration=0.0'), findsOneWidget);
       await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();
+      
+      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    });
+
+    testWidgets('should show warning when saving workout with exercise without sets', (WidgetTester tester) async {
+      // Set a fixed screen size
+      tester.binding.window.physicalSizeTestValue = const Size(1080, 1920);
+      tester.binding.window.devicePixelRatioTestValue = 1.0;
+      
+      // Build the widget
+      await tester.pumpWidget(MaterialApp(
+        home: WeightliftingPage(repository: mockRepository),
+      ));
+
+      // Add exercise without sets
+      final exerciseItem = find.text('Bench Press');
+      expect(exerciseItem, findsWidgets);
+      await tester.tap(exerciseItem.first);
+      await tester.pumpAndSettle();
+      
+      // Verify exercise card exists but has no sets
+      expect(find.byType(ExerciseCard), findsOneWidget);
+      
+      // Try to save workout
+      await tester.tap(find.byIcon(Icons.save));
+      await tester.pumpAndSettle();
+      
+      // Should show warning about missing sets
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.textContaining('has no sets'), findsOneWidget);
+      
+      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    });
+
+    testWidgets('should not show bottom bar when exercises have no sets', (WidgetTester tester) async {
+      // Set a fixed screen size
+      tester.binding.window.physicalSizeTestValue = const Size(1080, 1920);
+      tester.binding.window.devicePixelRatioTestValue = 1.0;
+      
+      // Build the widget
+      await tester.pumpWidget(MaterialApp(
+        home: WeightliftingPage(repository: mockRepository),
+      ));
+
+      // Add exercise without sets (volume will be 0)
+      final exerciseItem = find.text('Bench Press');
+      await tester.tap(exerciseItem.first);
+      await tester.pumpAndSettle();
+      
+      // Bottom bar should not be visible when total volume is 0
+      expect(find.byType(BottomBar), findsNothing);
       
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
     });

--- a/test/features/weight_training_log/presentation/widgets/bottom_bar_test.dart
+++ b/test/features/weight_training_log/presentation/widgets/bottom_bar_test.dart
@@ -23,4 +23,20 @@ void main() {
     await tester.tap(find.byType(BottomBar));
     expect(saved, true);
   });
+
+  testWidgets('BottomBar displays correct volume when volume is zero', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomBar(
+            totalVolume: 0.0,
+            primaryGreen: Colors.green,
+            onSaveWorkout: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Save Workout (0.0 kg)'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
On this PR, i resolve bug when users want to save their weighlitfing log. This change is to ensure users cannot save logs if an exercise or set is empty