### PR TITLE
FIX: Log history problem after merge

### DIFF
--- a/lib/features/food_log_history/services/food_log_history_service_impl.dart
+++ b/lib/features/food_log_history/services/food_log_history_service_impl.dart
@@ -83,7 +83,25 @@ class FoodLogHistoryServiceImpl implements FoodLogHistoryService {
   List<FoodLogHistoryItem> _convertFoodAnalysisResults(
       List<FoodAnalysisResult> results) {
     return results
-        .map((result) => FoodLogHistoryItem.fromFoodAnalysisResult(result))
+        .map((result) {
+          // Add 7 hours to the timestamp to convert from UTC to Indonesia time (UTC+7)
+          final localTimestamp = result.timestamp.add(const Duration(hours: 7));
+          
+          // Create a modified result with the adjusted timestamp
+          final adjustedResult = FoodAnalysisResult(
+            foodName: result.foodName,
+            ingredients: result.ingredients,
+            nutritionInfo: result.nutritionInfo,
+            warnings: result.warnings,
+            foodImageUrl: result.foodImageUrl,
+            timestamp: localTimestamp,  // Use the adjusted timestamp
+            id: result.id,
+            isLowConfidence: result.isLowConfidence,
+            userId: result.userId,
+          );
+          
+          return FoodLogHistoryItem.fromFoodAnalysisResult(adjustedResult);
+        })
         .toList();
   }
 }

--- a/lib/features/progress_charts_and_graphs/exercise_progress/domain/repositories/exercise_progress_repository_impl.dart
+++ b/lib/features/progress_charts_and_graphs/exercise_progress/domain/repositories/exercise_progress_repository_impl.dart
@@ -120,7 +120,6 @@ class ExerciseProgressRepositoryImpl implements ExerciseProgressRepository {
       // Monthly view - Show exactly 4 weeks of data for the current month
       
       // Get the first and last day of the current month
-      // ignore: unused_local_variable
       final firstDayOfMonth = DateTime(now.year, now.month, 1);
       final lastDayOfMonth = DateTime(now.year, now.month + 1, 0);
       

--- a/lib/features/weight_training_log/domain/models/weight_lifting.dart
+++ b/lib/features/weight_training_log/domain/models/weight_lifting.dart
@@ -36,11 +36,16 @@ class WeightLifting {
 
   // Create Exercise object from JSON
   factory WeightLifting.fromJson(Map<String, dynamic> json) {
+    // Safe conversion for metValue
+    final metValue = json['metValue'] is int 
+        ? (json['metValue'] as int).toDouble() 
+        : double.parse(json['metValue'].toString());
+        
     return WeightLifting(
       id: json['id'],
       name: json['name'],
       bodyPart: json['bodyPart'],
-      metValue: json['metValue'],
+      metValue: metValue,
       sets: json['sets'] != null
           ? List<WeightLiftingSet>.from(
               json['sets'].map((x) => WeightLiftingSet.fromJson(x)))


### PR DESCRIPTION
# Fix Fetching of Exercise Log History and Timestamp Handling in Food Log History
This PR addresses data fetching issues that occurred after the recent merge:
- Fixes incorrect or missing data when retrieving exercise log history from Firebase.
- Resolves timestamp-related issues in the food log history, ensuring accurate date filtering and ordering.

Changes include:
- Adjustments to the data retrieval logic for exercise logs to ensure correct integration with the progress page.
- Proper handling and parsing of `Timestamp` fields in food logs to avoid type mismatches or rendering errors.

These fixes ensure that the UI now accurately reflects historical input data for both exercise and food logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted food log timestamps to display local Indonesian time, ensuring accurate log history.
	- Improved JSON parsing for weight training logs, enforcing safe numerical conversion to prevent potential issues.

- **Chores**
	- Removed an extraneous internal comment from exercise progress data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->