### PR TITLE
FEAT: Implement Caloric Requirement Analyzer Based on User Input

### DIFF
--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -29,6 +29,9 @@ import 'package:pockeat/features/authentication/services/google_sign_in_service_
 import 'package:pockeat/features/health_metrics/domain/repositories/health_metrics_repository.dart';
 import 'package:pockeat/features/health_metrics/domain/repositories/health_metrics_repository_impl.dart';
 import 'package:pockeat/features/health_metrics/domain/service/health_metrics_check_service.dart';
+import 'package:pockeat/features/caloric_requirement/domain/repositories/caloric_requirement_repository.dart';
+import 'package:pockeat/features/caloric_requirement/domain/repositories/caloric_requirement_repository_impl.dart';
+import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pockeat/features/authentication/services/change_password_service.dart';
 import 'package:pockeat/features/authentication/services/change_password_service_impl.dart';
@@ -139,6 +142,14 @@ Future<void> setupDependencies() async {
 
   getIt.registerSingleton<HealthMetricsCheckService>(
   HealthMetricsCheckService(),
+  );
+
+  getIt.registerSingleton<CaloricRequirementRepository>(
+    CaloricRequirementRepositoryImpl(),
+  );
+
+  getIt.registerSingleton<CaloricRequirementService>(
+    CaloricRequirementService(),
   );
 
   // Register Food Log History module

--- a/lib/features/caloric_requirement/domain/models/caloric_requirement_model.dart
+++ b/lib/features/caloric_requirement/domain/models/caloric_requirement_model.dart
@@ -1,23 +1,37 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class CaloricRequirementModel {
+  final String userId; // Firestore doc ID
   final double bmr;
   final double tdee;
+  final DateTime timestamp;
 
   CaloricRequirementModel({
+    required this.userId,
     required this.bmr,
     required this.tdee,
+    required this.timestamp,
   });
 
   Map<String, dynamic> toMap() {
     return {
+      'userId': userId,
       'bmr': bmr,
       'tdee': tdee,
+      'timestamp': timestamp.toIso8601String(),
     };
   }
 
-  factory CaloricRequirementModel.fromMap(Map<String, dynamic> map) {
+  factory CaloricRequirementModel.fromFirestore(DocumentSnapshot doc) {
+    final rawData = doc.data();
+    if (rawData == null) throw Exception("Document data is null");
+
+    final data = rawData as Map<String, dynamic>;
     return CaloricRequirementModel(
-      bmr: (map['bmr'] as num).toDouble(),
-      tdee: (map['tdee'] as num).toDouble(),
+      userId: doc.id,
+      bmr: (data['bmr'] as num).toDouble(),
+      tdee: (data['tdee'] as num).toDouble(),
+      timestamp: DateTime.parse(data['timestamp']),
     );
   }
 }

--- a/lib/features/caloric_requirement/domain/models/caloric_requirement_model.dart
+++ b/lib/features/caloric_requirement/domain/models/caloric_requirement_model.dart
@@ -1,0 +1,23 @@
+class CaloricRequirementModel {
+  final double bmr;
+  final double tdee;
+
+  CaloricRequirementModel({
+    required this.bmr,
+    required this.tdee,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'bmr': bmr,
+      'tdee': tdee,
+    };
+  }
+
+  factory CaloricRequirementModel.fromMap(Map<String, dynamic> map) {
+    return CaloricRequirementModel(
+      bmr: (map['bmr'] as num).toDouble(),
+      tdee: (map['tdee'] as num).toDouble(),
+    );
+  }
+}

--- a/lib/features/caloric_requirement/domain/repositories/caloric_requirement_repository.dart
+++ b/lib/features/caloric_requirement/domain/repositories/caloric_requirement_repository.dart
@@ -1,0 +1,10 @@
+import '../models/caloric_requirement_model.dart';
+
+abstract class CaloricRequirementRepository {
+  Future<void> saveCaloricRequirement({
+    required String userId,
+    required CaloricRequirementModel result,
+  });
+
+  Future <CaloricRequirementModel?> getCaloricRequirement(String userId);
+}

--- a/lib/features/caloric_requirement/domain/repositories/caloric_requirement_repository_impl.dart
+++ b/lib/features/caloric_requirement/domain/repositories/caloric_requirement_repository_impl.dart
@@ -1,0 +1,39 @@
+// lib/features/health_metrics/caloric_requirement/domain/repositories/caloric_requirement_repository_impl.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
+import 'caloric_requirement_repository.dart';
+
+class CaloricRequirementRepositoryImpl implements CaloricRequirementRepository {
+  final FirebaseFirestore firestore;
+
+  CaloricRequirementRepositoryImpl({FirebaseFirestore? firestore})
+      : firestore = firestore ?? FirebaseFirestore.instance;
+
+  @override
+  Future<void> saveCaloricRequirement({
+    required String userId,
+    required CaloricRequirementModel result,
+  }) async {
+    try {
+      await firestore
+          .collection('caloric_requirements')
+          .doc(userId)
+          .set(result.toMap(), SetOptions(merge: true));
+    } catch (e) {
+      throw Exception('Failed to save caloric requirement: $e');
+    }
+  }
+
+  @override
+  Future<CaloricRequirementModel?> getCaloricRequirement(String userId) async {
+    try {
+      final doc = await firestore.collection('caloric_requirements').doc(userId).get();
+      if (!doc.exists) return null;
+
+      return CaloricRequirementModel.fromMap(doc.data()!);
+    } catch (e) {
+      throw Exception('Failed to fetch caloric requirement: $e');
+    }
+  }
+}

--- a/lib/features/caloric_requirement/domain/repositories/caloric_requirement_repository_impl.dart
+++ b/lib/features/caloric_requirement/domain/repositories/caloric_requirement_repository_impl.dart
@@ -31,7 +31,7 @@ class CaloricRequirementRepositoryImpl implements CaloricRequirementRepository {
       final doc = await firestore.collection('caloric_requirements').doc(userId).get();
       if (!doc.exists) return null;
 
-      return CaloricRequirementModel.fromMap(doc.data()!);
+      return CaloricRequirementModel.fromFirestore(doc);
     } catch (e) {
       throw Exception('Failed to fetch caloric requirement: $e');
     }

--- a/lib/features/caloric_requirement/domain/services/caloric_requirement_calculator.dart
+++ b/lib/features/caloric_requirement/domain/services/caloric_requirement_calculator.dart
@@ -1,0 +1,43 @@
+// lib/features/health_metrics/caloric_requirement/domain/services/caloric_requirement_calculator.dart
+
+class CaloricRequirementCalculator {
+  /// Calculates BMR using Mifflin-St Jeor formula
+  static double calculateBMR({
+    required double weight,
+    required double height,
+    required int age,
+    required String gender,
+  }) {
+    if (gender.toLowerCase() == "male") {
+      return 10 * weight + 6.25 * height - 5 * age + 5;
+    } else {
+      return 10 * weight + 6.25 * height - 5 * age - 161;
+    }
+  }
+
+  /// Returns the activity multiplier based on level
+  static double activityMultiplier(String activityLevel) {
+    switch (activityLevel.toLowerCase()) {
+      case "sedentary":
+        return 1.2;
+      case "light":
+        return 1.375; // 1–3x/week
+      case "moderate":
+        return 1.55; // 4–5x/week
+      case "active":
+        return 1.725; // daily or 3–4 intense
+      case "very active":
+        return 1.9; // 6–7 intense
+      case "extra active":
+        return 2.0; // daily intense or physical job
+      default:
+        return 1.2; // fallback
+    }
+  }
+
+
+  /// Calculates Total Daily Energy Expenditure (TDEE)
+  static double calculateTDEE(double bmr, String activityLevel) {
+    return bmr * activityMultiplier(activityLevel);
+  }
+}

--- a/lib/features/caloric_requirement/domain/services/caloric_requirement_service.dart
+++ b/lib/features/caloric_requirement/domain/services/caloric_requirement_service.dart
@@ -5,7 +5,10 @@ import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requi
 import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_calculator.dart';
 
 class CaloricRequirementService {
-  CaloricRequirementModel analyze(HealthMetricsModel model) {
+  CaloricRequirementModel analyze({
+    required String userId,
+    required HealthMetricsModel model,
+  }) {
     final bmr = CaloricRequirementCalculator.calculateBMR(
       weight: model.weight,
       height: model.height,
@@ -18,6 +21,11 @@ class CaloricRequirementService {
       model.activityLevel,
     );
 
-    return CaloricRequirementModel(bmr: bmr, tdee: tdee);
+    return CaloricRequirementModel(
+      userId: userId,
+      bmr: bmr,
+      tdee: tdee,
+      timestamp: DateTime.now(),
+    );
   }
 }

--- a/lib/features/caloric_requirement/domain/services/caloric_requirement_service.dart
+++ b/lib/features/caloric_requirement/domain/services/caloric_requirement_service.dart
@@ -1,0 +1,23 @@
+// lib/features/health_metrics/caloric_requirement/domain/services/caloric_requirement_service.dart
+
+import 'package:pockeat/features/health_metrics/domain/models/health_metrics_model.dart';
+import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
+import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_calculator.dart';
+
+class CaloricRequirementService {
+  CaloricRequirementModel analyze(HealthMetricsModel model) {
+    final bmr = CaloricRequirementCalculator.calculateBMR(
+      weight: model.weight,
+      height: model.height,
+      age: model.age,
+      gender: model.gender,
+    );
+
+    final tdee = CaloricRequirementCalculator.calculateTDEE(
+      bmr,
+      model.activityLevel,
+    );
+
+    return CaloricRequirementModel(bmr: bmr, tdee: tdee);
+  }
+}

--- a/lib/features/food_text_input/domain/services/food_text_input_service.dart
+++ b/lib/features/food_text_input/domain/services/food_text_input_service.dart
@@ -1,6 +1,5 @@
 import 'package:pockeat/features/api_scan/models/food_analysis.dart';
 import 'package:pockeat/features/api_scan/services/food/food_text_analysis_service.dart';
-import 'package:pockeat/core/di/service_locator.dart';
 import 'package:pockeat/features/food_text_input/domain/repositories/food_text_input_repository.dart';
 import 'package:uuid/uuid.dart';
 import 'package:firebase_auth/firebase_auth.dart';

--- a/lib/features/health_metrics/presentation/screens/activity_level_page.dart
+++ b/lib/features/health_metrics/presentation/screens/activity_level_page.dart
@@ -28,12 +28,12 @@ class ActivityLevelPage extends StatelessWidget {
       "description": "Daily exercise or intense exercise 3–4 times/week"
     },
     {
-      "value": "very_active",
+      "value": "very active",
       "label": "Very Active",
       "description": "Intense exercise 6–7 times/week"
     },
     {
-      "value": "extra_active",
+      "value": "extra active",
       "label": "Extra Active",
       "description": "Very intense daily exercise or physical job"
     },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,8 @@ import 'package:pockeat/features/food_text_input/domain/repositories/food_text_i
 import 'package:pockeat/features/food_text_input/presentation/screens/food_text_input_page.dart';
 import 'package:pockeat/features/health_metrics/domain/repositories/health_metrics_repository_impl.dart';
 import 'package:pockeat/features/health_metrics/domain/repositories/health_metrics_repository.dart';
+import 'package:pockeat/features/caloric_requirement/domain/repositories/caloric_requirement_repository.dart';
+import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_service.dart';
 import 'package:pockeat/features/health_metrics/presentation/screens/health_metrics_goals_page.dart';
 import 'package:pockeat/features/health_metrics/presentation/screens/height_weight_page.dart';
 import 'package:pockeat/features/health_metrics/presentation/screens/birthdate_page.dart';
@@ -122,6 +124,8 @@ void main() async {
             return HealthMetricsFormCubit(
               userId: user.uid,
               repository: getIt<HealthMetricsRepository>(),
+              caloricRequirementRepository: getIt<CaloricRequirementRepository>(),
+              caloricRequirementService: getIt<CaloricRequirementService>(),
             );
           },
         ),

--- a/test/features/caloric_requirement/domain/models/caloric_requirement_model_test.dart
+++ b/test/features/caloric_requirement/domain/models/caloric_requirement_model_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
+
+void main() {
+  group('CaloricRequirementModel', () {
+    test('should correctly create an instance via constructor', () {
+      final model = CaloricRequirementModel(bmr: 1500.0, tdee: 2000.0);
+
+      expect(model.bmr, 1500.0);
+      expect(model.tdee, 2000.0);
+    });
+
+    test('toMap should return correct map representation', () {
+      final model = CaloricRequirementModel(bmr: 1600.5, tdee: 2200.75);
+      final map = model.toMap();
+
+      expect(map, {'bmr': 1600.5, 'tdee': 2200.75});
+    });
+
+    test('fromMap should create an instance with correct values', () {
+      final map = {'bmr': 1400, 'tdee': 1800};
+      final model = CaloricRequirementModel.fromMap(map);
+
+      expect(model.bmr, 1400.0);
+      expect(model.tdee, 1800.0);
+    });
+
+    test('fromMap should handle num values like int and double correctly', () {
+      final map = {'bmr': 1350.75, 'tdee': 1750}; // mix of double and int
+      final model = CaloricRequirementModel.fromMap(map);
+
+      expect(model.bmr, 1350.75);
+      expect(model.tdee, 1750.0);
+    });
+  });
+}

--- a/test/features/caloric_requirement/domain/models/caloric_requirement_model_test.dart
+++ b/test/features/caloric_requirement/domain/models/caloric_requirement_model_test.dart
@@ -1,19 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
 
-class MockCaloricRequirementSnapshot extends Mock implements DocumentSnapshot {
-  final Map<String, dynamic>? _data;
-
-  MockCaloricRequirementSnapshot(this._data);
-
-  @override
-  Map<String, dynamic>? data() => _data;
-
-  @override
-  String get id => _data?['userId'] ?? 'test-user';
-}
+// Mock class using mocktail
+class MockDocumentSnapshot extends Mock implements DocumentSnapshot {}
 
 void main() {
   group('CaloricRequirementModel', () {
@@ -57,7 +48,10 @@ void main() {
         'timestamp': DateTime(2024, 1, 1).toIso8601String(),
       };
 
-      final snapshot = MockCaloricRequirementSnapshot(mockData);
+      final snapshot = MockDocumentSnapshot();
+      when(() => snapshot.data()).thenReturn(mockData);
+      when(() => snapshot.id).thenReturn('test-user');
+      
       final model = CaloricRequirementModel.fromFirestore(snapshot);
 
       expect(model.userId, equals('test-user'));
@@ -67,7 +61,8 @@ void main() {
     });
 
     test('fromFirestore throws when data is null', () {
-      final snapshot = MockCaloricRequirementSnapshot(null);
+      final snapshot = MockDocumentSnapshot();
+      when(() => snapshot.data()).thenReturn(null);
 
       expect(() => CaloricRequirementModel.fromFirestore(snapshot), throwsException);
     });
@@ -80,7 +75,10 @@ void main() {
         'timestamp': DateTime(2024, 1, 1).toIso8601String(),
       };
 
-      final snapshot = MockCaloricRequirementSnapshot(mockData);
+      final snapshot = MockDocumentSnapshot();
+      when(() => snapshot.data()).thenReturn(mockData);
+      when(() => snapshot.id).thenReturn('user-id');
+
       final model = CaloricRequirementModel.fromFirestore(snapshot);
 
       expect(model.bmr, equals(1350.0));

--- a/test/features/caloric_requirement/domain/repositories/caloric_requirement_repository_test.dart
+++ b/test/features/caloric_requirement/domain/repositories/caloric_requirement_repository_test.dart
@@ -21,7 +21,13 @@ void main() {
   late CaloricRequirementRepositoryImpl repository;
 
   const userId = 'test-user';
-  final testModel = CaloricRequirementModel(bmr: 1500.0, tdee: 2000.0);
+  final timestamp = DateTime(2024, 4, 12, 10, 0, 0);
+  final testModel = CaloricRequirementModel(
+    userId: userId,
+    bmr: 1500.0,
+    tdee: 2000.0,
+    timestamp: timestamp,
+  );
 
   setUp(() {
     mockFirestore = MockFirebaseFirestore();
@@ -62,13 +68,21 @@ void main() {
   test('getCaloricRequirement returns model if document exists', () async {
     when(mockDocRef.get()).thenAnswer((_) async => mockSnapshot);
     when(mockSnapshot.exists).thenReturn(true);
-    when(mockSnapshot.data()).thenReturn(testModel.toMap());
+    when(mockSnapshot.id).thenReturn(userId);
+    when(mockSnapshot.data()).thenReturn({
+      'userId': userId,
+      'bmr': 1500.0,
+      'tdee': 2000.0,
+      'timestamp': timestamp.toIso8601String(),
+    });
 
     final result = await repository.getCaloricRequirement(userId);
 
     expect(result, isA<CaloricRequirementModel>());
     expect(result?.bmr, 1500.0);
     expect(result?.tdee, 2000.0);
+    expect(result?.timestamp, timestamp);
+    expect(result?.userId, userId);
   });
 
   test('getCaloricRequirement returns null if document does not exist', () async {

--- a/test/features/caloric_requirement/domain/repositories/caloric_requirement_repository_test.dart
+++ b/test/features/caloric_requirement/domain/repositories/caloric_requirement_repository_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mockito/annotations.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
+import 'package:pockeat/features/caloric_requirement/domain/repositories/caloric_requirement_repository_impl.dart';
+
+import 'caloric_requirement_repository_test.mocks.dart';
+
+@GenerateMocks([
+  FirebaseFirestore,
+  CollectionReference,
+  DocumentReference,
+  DocumentSnapshot,
+])
+void main() {
+  late MockFirebaseFirestore mockFirestore;
+  late MockCollectionReference<Map<String, dynamic>> mockCollection;
+  late MockDocumentReference<Map<String, dynamic>> mockDocRef;
+  late MockDocumentSnapshot<Map<String, dynamic>> mockSnapshot;
+  late CaloricRequirementRepositoryImpl repository;
+
+  const userId = 'test-user';
+  final testModel = CaloricRequirementModel(bmr: 1500.0, tdee: 2000.0);
+
+  setUp(() {
+    mockFirestore = MockFirebaseFirestore();
+    mockCollection = MockCollectionReference();
+    mockDocRef = MockDocumentReference();
+    mockSnapshot = MockDocumentSnapshot();
+
+    when(mockFirestore.collection('caloric_requirements')).thenReturn(mockCollection);
+    when(mockCollection.doc(userId)).thenReturn(mockDocRef);
+
+    repository = CaloricRequirementRepositoryImpl(firestore: mockFirestore);
+  });
+
+  test('CaloricRequirementRepositoryImpl initializes correctly', () {
+    expect(repository, isA<CaloricRequirementRepositoryImpl>());
+  });
+
+  test('saveCaloricRequirement stores data successfully', () async {
+    await repository.saveCaloricRequirement(userId: userId, result: testModel);
+
+    verify(mockFirestore.collection('caloric_requirements')).called(1);
+    verify(mockCollection.doc(userId)).called(1);
+    verify(mockDocRef.set(testModel.toMap(), any)).called(1);
+  });
+
+  test('saveCaloricRequirement throws exception on Firestore failure', () async {
+    when(mockDocRef.set(any, any)).thenThrow(FirebaseException(
+      plugin: 'firestore',
+      message: 'Write failed',
+    ));
+
+    expect(
+      () => repository.saveCaloricRequirement(userId: userId, result: testModel),
+      throwsException,
+    );
+  });
+
+  test('getCaloricRequirement returns model if document exists', () async {
+    when(mockDocRef.get()).thenAnswer((_) async => mockSnapshot);
+    when(mockSnapshot.exists).thenReturn(true);
+    when(mockSnapshot.data()).thenReturn(testModel.toMap());
+
+    final result = await repository.getCaloricRequirement(userId);
+
+    expect(result, isA<CaloricRequirementModel>());
+    expect(result?.bmr, 1500.0);
+    expect(result?.tdee, 2000.0);
+  });
+
+  test('getCaloricRequirement returns null if document does not exist', () async {
+    when(mockDocRef.get()).thenAnswer((_) async => mockSnapshot);
+    when(mockSnapshot.exists).thenReturn(false);
+
+    final result = await repository.getCaloricRequirement(userId);
+
+    expect(result, isNull);
+  });
+
+  test('getCaloricRequirement throws exception on Firestore failure', () async {
+    when(mockDocRef.get()).thenThrow(FirebaseException(
+      plugin: 'firestore',
+      message: 'Read failed',
+    ));
+
+    expect(() => repository.getCaloricRequirement(userId), throwsException);
+  });
+}

--- a/test/features/caloric_requirement/domain/services/caloric_requirement_service_test.dart
+++ b/test/features/caloric_requirement/domain/services/caloric_requirement_service_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_calculator.dart';
 import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_service.dart';
 import 'package:pockeat/features/health_metrics/domain/models/health_metrics_model.dart';
-import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
 
 void main() {
   group('CaloricRequirementCalculator', () {

--- a/test/features/caloric_requirement/domain/services/caloric_requirement_service_test.dart
+++ b/test/features/caloric_requirement/domain/services/caloric_requirement_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_calculator.dart';
 import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_service.dart';
 import 'package:pockeat/features/health_metrics/domain/models/health_metrics_model.dart';
+import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
 
 void main() {
   group('CaloricRequirementCalculator', () {
@@ -33,12 +34,12 @@ void main() {
         'active': 1.725,
         'very active': 1.9,
         'extra active': 2.0,
-        'unknown': 1.2, // default fallback
+        'unknown': 1.2, // fallback
       };
 
-      levels.forEach((level, expectedMultiplier) {
+      levels.forEach((level, expected) {
         final result = CaloricRequirementCalculator.activityMultiplier(level);
-        expect(result, expectedMultiplier);
+        expect(result, expected);
       });
     });
 
@@ -62,7 +63,10 @@ void main() {
       );
 
       final service = CaloricRequirementService();
-      final result = service.analyze(model);
+      final result = service.analyze(
+        userId: model.userId,
+        model: model,
+        );
 
       final expectedBMR = CaloricRequirementCalculator.calculateBMR(
         weight: 65,
@@ -76,8 +80,10 @@ void main() {
         'active',
       );
 
+      expect(result.userId, model.userId);
       expect(result.bmr, closeTo(expectedBMR, 0.01));
       expect(result.tdee, closeTo(expectedTDEE, 0.01));
+      expect(result.timestamp, isA<DateTime>());
     });
   });
 }

--- a/test/features/caloric_requirement/domain/services/caloric_requirement_service_test.dart
+++ b/test/features/caloric_requirement/domain/services/caloric_requirement_service_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_calculator.dart';
+import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_service.dart';
+import 'package:pockeat/features/health_metrics/domain/models/health_metrics_model.dart';
+
+void main() {
+  group('CaloricRequirementCalculator', () {
+    test('calculates BMR for male correctly', () {
+      final bmr = CaloricRequirementCalculator.calculateBMR(
+        weight: 70,
+        height: 175,
+        age: 25,
+        gender: 'male',
+      );
+      expect(bmr, closeTo(10 * 70 + 6.25 * 175 - 5 * 25 + 5, 0.01));
+    });
+
+    test('calculates BMR for female correctly', () {
+      final bmr = CaloricRequirementCalculator.calculateBMR(
+        weight: 60,
+        height: 160,
+        age: 30,
+        gender: 'female',
+      );
+      expect(bmr, closeTo(10 * 60 + 6.25 * 160 - 5 * 30 - 161, 0.01));
+    });
+
+    test('returns correct activity multiplier for all levels', () {
+      final levels = {
+        'sedentary': 1.2,
+        'light': 1.375,
+        'moderate': 1.55,
+        'active': 1.725,
+        'very active': 1.9,
+        'extra active': 2.0,
+        'unknown': 1.2, // default fallback
+      };
+
+      levels.forEach((level, expectedMultiplier) {
+        final result = CaloricRequirementCalculator.activityMultiplier(level);
+        expect(result, expectedMultiplier);
+      });
+    });
+
+    test('calculates TDEE correctly', () {
+      final bmr = 1500.0;
+      final tdee = CaloricRequirementCalculator.calculateTDEE(bmr, 'moderate');
+      expect(tdee, closeTo(1500.0 * 1.55, 0.01));
+    });
+  });
+
+  group('CaloricRequirementService', () {
+    test('analyze returns correct model based on HealthMetricsModel', () {
+      final model = HealthMetricsModel(
+        userId: 'abc',
+        height: 170,
+        weight: 65,
+        age: 24,
+        gender: 'male',
+        activityLevel: 'active',
+        fitnessGoal: 'Maintain',
+      );
+
+      final service = CaloricRequirementService();
+      final result = service.analyze(model);
+
+      final expectedBMR = CaloricRequirementCalculator.calculateBMR(
+        weight: 65,
+        height: 170,
+        age: 24,
+        gender: 'male',
+      );
+
+      final expectedTDEE = CaloricRequirementCalculator.calculateTDEE(
+        expectedBMR,
+        'active',
+      );
+
+      expect(result.bmr, closeTo(expectedBMR, 0.01));
+      expect(result.tdee, closeTo(expectedTDEE, 0.01));
+    });
+  });
+}

--- a/test/features/health_metrics/presentation/screens/form_cubit_test.dart
+++ b/test/features/health_metrics/presentation/screens/form_cubit_test.dart
@@ -1,21 +1,32 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
-
 import 'package:pockeat/features/health_metrics/domain/models/health_metrics_model.dart';
 import 'package:pockeat/features/health_metrics/presentation/screens/form_cubit.dart';
 import 'package:pockeat/features/health_metrics/domain/repositories/health_metrics_repository_impl.dart';
+import 'package:pockeat/features/caloric_requirement/domain/repositories/caloric_requirement_repository.dart';
+import 'package:pockeat/features/caloric_requirement/domain/models/caloric_requirement_model.dart';
+import 'package:pockeat/features/caloric_requirement/domain/services/caloric_requirement_service.dart';
 
 import 'form_cubit_test.mocks.dart';
 
-@GenerateMocks([HealthMetricsRepositoryImpl])
+@GenerateMocks([HealthMetricsRepositoryImpl, CaloricRequirementRepository, CaloricRequirementService])
 void main() {
   late MockHealthMetricsRepositoryImpl mockRepo;
+  late MockCaloricRequirementRepository mockCaloricRepo;
+  late MockCaloricRequirementService mockCaloricService;
   late HealthMetricsFormCubit cubit;
 
   setUp(() {
     mockRepo = MockHealthMetricsRepositoryImpl();
-    cubit = HealthMetricsFormCubit(repository: mockRepo, userId: 'user123');
+    mockCaloricRepo = MockCaloricRequirementRepository();
+    mockCaloricService = MockCaloricRequirementService();
+    cubit = HealthMetricsFormCubit(
+      repository: mockRepo,
+      userId: 'user123',
+      caloricRequirementRepository: mockCaloricRepo,
+      caloricRequirementService: mockCaloricService,
+    );
   });
 
   test('initial state is correct', () {
@@ -47,21 +58,20 @@ void main() {
   });
 
   test('setGender updates gender', () {
-  cubit.setGender("Male");
-  expect(cubit.state.gender, "Male");
+    cubit.setGender("Male");
+    expect(cubit.state.gender, "Male");
 
-  cubit.setGender("Female");
-  expect(cubit.state.gender, "Female");
-});
+    cubit.setGender("Female");
+    expect(cubit.state.gender, "Female");
+  });
 
-test('setActivityLevel updates activity level', () {
-  cubit.setActivityLevel("Moderately Active");
-  expect(cubit.state.activityLevel, "Moderately Active");
+  test('setActivityLevel updates activity level', () {
+    cubit.setActivityLevel("Moderately Active");
+    expect(cubit.state.activityLevel, "Moderately Active");
 
-  cubit.setActivityLevel("Sedentary");
-  expect(cubit.state.activityLevel, "Sedentary");
-});
-
+    cubit.setActivityLevel("Sedentary");
+    expect(cubit.state.activityLevel, "Sedentary");
+  });
 
   test('submit calls repository when all data is valid', () async {
     cubit
@@ -73,9 +83,28 @@ test('setActivityLevel updates activity level', () {
       ..setActivityLevel("Lightly Active")
       ..toggleGoal("Lose Weight");
 
+    // Mock analyze call
+    when(mockCaloricService.analyze(
+        userId: anyNamed('userId'),
+        model: anyNamed('model'),
+      )).thenReturn(
+      CaloricRequirementModel(
+        userId: 'user123',
+        bmr: 1500,
+        tdee: 2000,
+        timestamp: DateTime.now(),
+      ),
+    );
+
     await cubit.submit();
 
+    // Verify saveHealthMetrics call
     verify(mockRepo.saveHealthMetrics(any)).called(1);
+    // Verify saveCaloricRequirement call
+    verify(mockCaloricRepo.saveCaloricRequirement(
+      userId: 'user123',
+      result: anyNamed('result'),
+    )).called(1);
   });
 
   test('submit throws if "Other" goal has no reason', () async {
@@ -102,10 +131,98 @@ test('setActivityLevel updates activity level', () {
       ..toggleGoal("Other")
       ..setOtherGoalReason("Build muscle");
 
+    when(mockCaloricService.analyze(
+          userId: anyNamed('userId'),
+          model: anyNamed('model'),
+        )).thenReturn(
+      CaloricRequirementModel(
+        userId: 'user123',
+        bmr: 1500,
+        tdee: 2000,
+        timestamp: DateTime.now(),
+      ),
+    );
+
     await cubit.submit();
 
-    verify(mockRepo.saveHealthMetrics(argThat(predicate((model) =>
-    (model as HealthMetricsModel).fitnessGoal.contains("Other: Build muscle")
-  )))).called(1);
+    verify(mockRepo.saveHealthMetrics(argThat(predicate((model) {
+      final goal = (model as HealthMetricsModel).fitnessGoal;
+      return goal.contains("Other: Build muscle");
+    })))).called(1);
+  });
+
+  test('submit calculates and saves caloric requirement', () async {
+    when(mockCaloricService.analyze(
+          userId: anyNamed('userId'),
+          model: anyNamed('model'),
+        )).thenReturn(
+      CaloricRequirementModel(
+        userId: 'user123',
+        bmr: 1600,
+        tdee: 2100,
+        timestamp: DateTime.now(),
+      ),
+    );
+
+    cubit
+      ..setHeightWeight(height: 180, weight: 75)
+      ..setBirthDate(DateTime(1995, 5, 5))
+      ..setDesiredWeight(70)
+      ..setWeeklyGoal(1)
+      ..setGender("Male")
+      ..setActivityLevel("moderate")
+      ..toggleGoal("Build Muscle");
+
+    await cubit.submit();
+
+    verify(mockCaloricRepo.saveCaloricRequirement(
+      userId: 'user123',
+      result: anyNamed('result'),
+    )).called(1);
+  });
+
+  test('submit computes correct BMR and TDEE for Male with moderate activity', () async {
+    final now = DateTime.now();
+    int age = now.year - 2000;
+    if (now.month < 1 || (now.month == 1 && now.day < 1)) {
+      age--;
+    }
+    final expectedBMR = 10 * 75 + 6.25 * 180 - 5 * age + 5;
+    final expectedTDEE = expectedBMR * 1.55;
+
+    final fakeResult = CaloricRequirementModel(
+      userId: 'user123',
+      bmr: expectedBMR,
+      tdee: expectedTDEE,
+      timestamp: DateTime.now(),
+    );
+
+    when(mockCaloricService.analyze(
+        userId: anyNamed('userId'),
+        model: anyNamed('model'),
+      )).thenReturn(fakeResult);
+
+    cubit
+      ..setHeightWeight(height: 180, weight: 75)
+      ..setBirthDate(DateTime(2000, 1, 1))
+      ..setDesiredWeight(70)
+      ..setWeeklyGoal(0.5)
+      ..setGender("Male")
+      ..setActivityLevel("moderate")
+      ..toggleGoal("Lose Weight");
+
+    await cubit.submit();
+
+    verify(mockCaloricRepo.saveCaloricRequirement(
+      userId: 'user123',
+      result: argThat(
+        predicate((model) =>
+          model is CaloricRequirementModel &&
+          (model.bmr - expectedBMR).abs() < 0.01 &&
+          (model.tdee - expectedTDEE).abs() < 0.01,
+        ),
+        named: 'result',
+      ),
+    )).called(1);
   });
 }


### PR DESCRIPTION
## ✨ Caloric Requirement Feature Integration

This pull request introduces a new feature for handling **caloric requirements** within the application. The implementation includes new **models**, **repositories**, **services**, and **tests** to support the analysis and storage of user-specific caloric needs.

> ⚠️ **Note on Integration**:  
> The current BMR logic overlaps with Kimi’s implementation in the Cardio Log feature. For a clean and unified experience, we may need to **refactor or align** the shared logic across both modules during integration with Kimi’s and Rama’s features.  
> You can explore the implementation inside the `lib/features/caloric_requirement` folder.

---

### ✅ Highlights of This PR

✅ New Caloric Requirement Feature
➕ Model
[caloric_requirement_model.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Defines CaloricRequirementModel with fields for BMR, TDEE, timestamp, and Firestore serialization.

📦 Repository
[caloric_requirement_repository.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Declares an abstract interface CaloricRequirementRepository.

[caloric_requirement_repository_impl.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Implements the repository using Firestore for saving and retrieving data.

🧠 Service
[caloric_requirement_calculator.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Provides pure functions to compute BMR and TDEE from user attributes.

[caloric_requirement_service.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Analyzes a HealthMetricsModel to return a fully constructed CaloricRequirementModel.

🧩 Dependency Injection & Integration
[service_locator.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Registers CaloricRequirementRepository and CaloricRequirementService.
[[1]](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1) [[2]](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1)

[main.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Injects the repository and service into HealthMetricsFormCubit.
[[1]](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1) [[2]](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1)

🧪 Tests
✅ Unit Tests
[caloric_requirement_model_test.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Validates model behavior, toMap(), and fromFirestore() parsing.

[caloric_requirement_repository_test.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Mocks Firestore for repository storage/retrieval tests.

[caloric_requirement_service_test.dart](https://github.com/Pemuda-Pembuka-Langkah/pockeat-mobile/compare/staging...PBI-dev-laras-94?expand=1):
Confirms BMR/TDEE calculations and model generation logic from HealthMetricsModel.