### PR TITLE
Integrate over caloric requirement for heart bar and mood state and created pet Information model for better fetch

### DIFF
--- a/lib/features/homepage/presentation/widgets/heart_bar_widget.dart
+++ b/lib/features/homepage/presentation/widgets/heart_bar_widget.dart
@@ -6,8 +6,13 @@ import 'package:flutter/material.dart';
 class HeartBarWidget extends StatelessWidget {
   final int heart;
   static const int maxHeart = 4;
+  final bool isCalorieOverTarget;
 
-  const HeartBarWidget({super.key, required this.heart});
+  const HeartBarWidget({
+    super.key,
+    required this.heart,
+    required this.isCalorieOverTarget,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +45,11 @@ class HeartBarWidget extends StatelessWidget {
   Widget _buildHeart(bool filled) {
     return Icon(
       Icons.favorite,
-      color: filled ? Colors.red : Colors.grey.shade300,
+      color: filled
+          ? isCalorieOverTarget
+              ? Colors.purple
+              : Colors.red
+          : Colors.grey.shade300,
       size: 32,
     );
   }

--- a/lib/features/pet_companion/domain/model/pet_information.dart
+++ b/lib/features/pet_companion/domain/model/pet_information.dart
@@ -1,0 +1,12 @@
+class PetInformation {
+  final String name = 'Panda';
+  final int heart;
+  final String mood;
+  final bool isCalorieOverTarget;
+
+  PetInformation({
+    required this.heart,
+    required this.mood,
+    required this.isCalorieOverTarget,
+  });
+}

--- a/lib/features/pet_companion/domain/services/pet_service.dart
+++ b/lib/features/pet_companion/domain/services/pet_service.dart
@@ -1,3 +1,5 @@
+import 'package:pockeat/features/pet_companion/domain/model/pet_information.dart';
+
 abstract class PetService {
   /// Get the pet mood
   ///
@@ -19,4 +21,19 @@ abstract class PetService {
   /// between 50% and 75% of the target calories returns 3
   /// between 75% and 100% of the target calories returns 4
   Future<int> getPetHeart(String userId);
+
+  /// Get the pet calorie over target
+  ///
+  /// [userId] is the user id
+  /// Returns the pet calorie over target
+  ///
+  /// returns true if the pet has consumed more calories than the target
+  /// returns false if the pet has consumed less than the target
+  Future<bool> getIsPetCalorieOverTarget(String userId);
+
+  /// Get the pet information
+  ///
+  /// [userId] is the user id
+  /// Returns the pet information
+  Future<PetInformation> getPetInformation(String userId);
 }

--- a/lib/features/pet_companion/domain/services/pet_service_impl.dart
+++ b/lib/features/pet_companion/domain/services/pet_service_impl.dart
@@ -5,6 +5,7 @@ import 'package:get_it/get_it.dart';
 // Project imports:
 import 'package:pockeat/features/calorie_stats/services/calorie_stats_service.dart';
 import 'package:pockeat/features/food_log_history/services/food_log_history_service.dart';
+import 'package:pockeat/features/pet_companion/domain/model/pet_information.dart';
 import 'package:pockeat/features/pet_companion/domain/services/pet_service.dart';
 
 class PetServiceImpl implements PetService {
@@ -54,5 +55,34 @@ class PetServiceImpl implements PetService {
     } else {
       return 0;
     }
+  }
+
+  @override
+  Future<bool> getIsPetCalorieOverTarget(String userId) async {
+    final stats =
+        await calorieStatsService.calculateStatsForDate(userId, DateTime.now());
+
+    final caloriesConsumed = stats.caloriesConsumed;
+    final caloricRequirement =
+        await firestore.collection('caloric_requirements').doc(userId).get();
+
+    final targetCalories = caloricRequirement.data()!['tdee'];
+
+    return (caloriesConsumed - targetCalories) > targetCalories * 0.2;
+  }
+
+  @override
+  Future<PetInformation> getPetInformation(String userId) async {
+    final isCalorieOverTarget = await getIsPetCalorieOverTarget(userId);
+    final heart = await getPetHeart(userId);
+    var mood = await getPetMood(userId);
+    if (isCalorieOverTarget) {
+      mood = 'sad';
+    }
+    return PetInformation(
+      isCalorieOverTarget: isCalorieOverTarget,
+      heart: heart,
+      mood: mood,
+    );
   }
 }

--- a/test/features/homepage/presentation/homepage_test.dart
+++ b/test/features/homepage/presentation/homepage_test.dart
@@ -20,8 +20,9 @@ import 'package:pockeat/features/homepage/presentation/screens/overview_section.
 import 'package:pockeat/features/homepage/presentation/screens/pet_homepage_section.dart';
 import 'package:pockeat/features/homepage/presentation/widgets/pet_companion_widget.dart';
 import 'package:pockeat/features/homepage/presentation/widgets/streak_counter_widget.dart';
-import 'package:pockeat/features/homepage/presentation/widgets/streak_counter_widget.dart';
 import 'package:pockeat/features/pet_companion/domain/services/pet_service.dart';
+import 'package:pockeat/features/pet_companion/domain/model/pet_information.dart';
+
 import 'homepage_test.mocks.dart';
 
 @GenerateNiceMocks([
@@ -94,6 +95,13 @@ void main() async {
         .thenAnswer((_) async => 1);
     when(mockPetService.getPetMood(any)).thenAnswer((_) async => 'happy');
     when(mockPetService.getPetHeart(any)).thenAnswer((_) async => 4);
+    when(mockPetService.getPetInformation(any)).thenAnswer((_) async =>
+        PetInformation(
+          mood: 'happy',
+          heart: 4,
+          isCalorieOverTarget: false,
+        ));
+
     when(mockSharedPreferences.getString(any))
         .thenReturn('assets/images/gym.jpg');
   });

--- a/test/features/pet_companion/domain/model/pet_information_test.dart
+++ b/test/features/pet_companion/domain/model/pet_information_test.dart
@@ -1,0 +1,59 @@
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:pockeat/features/pet_companion/domain/model/pet_information.dart';
+
+void main() {
+  group('PetInformation', () {
+    test('should create a valid model from constructor', () {
+      // Arrange & Act
+      final model = PetInformation(
+        heart: 5,
+        mood: 'Happy',
+        isCalorieOverTarget: false,
+      );
+
+      // Assert
+      expect(model.name, 'Panda');
+      expect(model.heart, 5);
+      expect(model.mood, 'Happy');
+      expect(model.isCalorieOverTarget, false);
+    });
+
+    test('should create a model with different values', () {
+      // Arrange & Act
+      final model = PetInformation(
+        heart: 2,
+        mood: 'Sad',
+        isCalorieOverTarget: true,
+      );
+
+      // Assert
+      expect(model.name, 'Panda'); // name is fixed
+      expect(model.heart, 2);
+      expect(model.mood, 'Sad');
+      expect(model.isCalorieOverTarget, true);
+    });
+
+    test('should have fixed name as Panda', () {
+      // Arrange & Act
+      final model1 = PetInformation(
+        heart: 3,
+        mood: 'Neutral',
+        isCalorieOverTarget: false,
+      );
+      
+      final model2 = PetInformation(
+        heart: 4,
+        mood: 'Excited',
+        isCalorieOverTarget: true,
+      );
+
+      // Assert
+      expect(model1.name, 'Panda');
+      expect(model2.name, 'Panda');
+      expect(model1.name, equals(model2.name));
+    });
+  });
+} 


### PR DESCRIPTION
What was added:
- Pet Information model that contains the name, heart, mood, and indicator for over calorie consumed
- Method for getIsPetCalorieOverTarget in pet service
- Method for getPetInformation in pet service
- Tests for pet information model
- Tests for pet service for the new methods

What was changed:
- heart bar will show purple if the over calorie is true (over by the 120% calorie requirement as a threshold)

Screenshots:
- Screenshots will be added when the API problem is resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified pet information model that consolidates heart, mood, and calorie status.
  - The pet's heart bar now visually indicates when calorie intake exceeds the target, using a new color.
- **Enhancements**
  - Pet mood is now automatically set to "sad" if calorie intake is over the target, regardless of other factors.
- **Bug Fixes**
  - Improved consistency and accuracy in displaying pet stats by fetching all data in a single operation.
- **Tests**
  - Added comprehensive tests for the new pet information model and calorie threshold logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->