### PR TITLE
PLEASE THIS IS THE LAST TIME I WILL MESS WITH CARDIO LOG FEATURE 

### DIFF
--- a/lib/features/cardio_log/presentation/widgets/cycling_form.dart
+++ b/lib/features/cardio_log/presentation/widgets/cycling_form.dart
@@ -61,6 +61,8 @@ class CyclingFormState extends State<CyclingForm> {
           .split('.')
           .last; // 'mountain', 'commute', or 'stationary'
 
+      widget.onCalculate(totalDistance, duration, type);
+      
       return CalorieCalculator.calculateCyclingCalories(
         distanceKm: totalDistance,
         duration: duration,

--- a/lib/features/cardio_log/presentation/widgets/running_form.dart
+++ b/lib/features/cardio_log/presentation/widgets/running_form.dart
@@ -56,6 +56,8 @@ class RunningFormState extends State<RunningForm> {
         return 0.0;
       }
 
+      widget.onCalculate(totalDistance, duration);
+
       return CalorieCalculator.calculateRunningCalories(
         distanceKm: totalDistance,
         duration: duration,

--- a/lib/features/cardio_log/presentation/widgets/swimming_form.dart
+++ b/lib/features/cardio_log/presentation/widgets/swimming_form.dart
@@ -56,6 +56,13 @@ class SwimmingFormState extends State<SwimmingForm> {
         return 0.0;
       }
 
+      widget.onCalculate(
+              selectedLaps,
+              customPoolLength,
+              selectedStroke,
+              duration,
+            );
+            
       return CalorieCalculator.calculateSwimmingCalories(
         laps: selectedLaps,
         poolLength: customPoolLength,


### PR DESCRIPTION
This PR fixes an issue where cardio input forms (**Running**, **Cycling**, **Swimming**) no longer triggered validation, distance updates, or snackbar feedback due to a missing `onCalculate` callback invocation.

---

### 🐛 Root Cause

In a recent refactor, the `calculateCalories` methods inside the form widgets were modified to call `CalorieCalculator` directly, bypassing the `onCalculate` callback passed from `CardioInputPage`.

As a result:

- State variables like `runningDistance` and `runningDuration` were never updated.
- Input validation (e.g. distance must not be 0) silently failed.
- Snackbars never appeared after saving an activity.

---

### ✅ Fix Summary

- Restored calls to `widget.onCalculate(distance, duration)` in all `calculateCalories` methods.
- Preserved use of `CalorieCalculator` to compute calories using `healthMetrics`.
- Ensured both state updates and calorie computations work as intended.

---

### 💡 Notes

This fix ensures that:
- Form inputs properly update the parent page state
- Input validation and snackbar feedback are re-enabled
- Calorie calculations remain accurate with user health data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cycling, running, and swimming activity forms now provide additional feedback by invoking a callback with activity details when calculating calories. This enables enhanced integration with other features that respond to calculation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->