### PR TITLE
Refinements: Fix Incorrect Label Mapping for exercise_type in Smart Log Exercise

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,36 +1,9 @@
+echo "husky - DEPRECATED
+
+Please remove the following two lines from $0:
+
 #!/usr/bin/env sh
-if [ -z "$husky_skip_init" ]; then
-  debug () {
-    if [ "$HUSKY_DEBUG" = "1" ]; then
-      echo "husky (debug) - $1"
-    fi
-  }
+. \"\$(dirname -- \"\$0\")/_/husky.sh\"
 
-  readonly hook_name="$(basename -- "$0")"
-  debug "starting $hook_name..."
-
-  if [ "$HUSKY" = "0" ]; then
-    debug "HUSKY env variable is set to 0, skipping hook"
-    exit 0
-  fi
-
-  if [ -f ~/.huskyrc ]; then
-    debug "sourcing ~/.huskyrc"
-    . ~/.huskyrc
-  fi
-
-  readonly husky_skip_init=1
-  export husky_skip_init
-  sh -e "$0" "$@"
-  exitCode="$?"
-
-  if [ $exitCode != 0 ]; then
-    echo "husky - $hook_name hook exited with code $exitCode (error)"
-  fi
-
-  if [ $exitCode = 127 ]; then
-    echo "husky - command not found in PATH=$PATH"
-  fi
-
-  exit $exitCode
-fi
+They WILL FAIL in v10.0.0
+"

--- a/lib/features/smart_exercise_log/presentation/widgets/analysis_result_widget.dart
+++ b/lib/features/smart_exercise_log/presentation/widgets/analysis_result_widget.dart
@@ -207,7 +207,7 @@ class AnalysisResultWidget extends StatelessWidget {
   Widget _buildMissingInfoSection() {
     final missingInfo = analysisResult.missingInfo!;
     final missingLabels = {
-      'type': 'Exercise type',
+      'exercise_type': 'Exercise type',
       'duration': 'Exercise duration',
       'intensity': 'Exercise intensity',
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
-  "name": "Mobile App",
+  "name": "pockeat-mobile",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
-        "husky": "^8.0.3"
+        "husky": "^9.1.7"
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "husky": "^8.0.3"
+    "husky": "^9.1.7"
   }
 }

--- a/test/features/smart_exercise_log/presentation/widgets/analysis_result_widget_test.dart
+++ b/test/features/smart_exercise_log/presentation/widgets/analysis_result_widget_test.dart
@@ -203,7 +203,7 @@ void main() {
         metValue: 0.0, // Empty MET value for unknown workout
         timestamp: DateTime.now(),
         originalInput: 'Exercise this morning',
-        missingInfo: ['type', 'duration', 'intensity'],
+        missingInfo: ['exercise_type', 'duration', 'intensity'],
         userId: 'test-user-123',
       );
 

--- a/test/features/smart_exercise_log/presentation/widgets/analysis_result_widget_test.dart
+++ b/test/features/smart_exercise_log/presentation/widgets/analysis_result_widget_test.dart
@@ -352,6 +352,72 @@ void main() {
       expect(find.text('0.0'), findsNothing); // MET value 0 should not be displayed
     });
 
+    testWidgets('positive case: shows complete data with summary and valid MET', (WidgetTester tester) async {
+      final complete = ExerciseAnalysisResult(
+        exerciseType: 'Cycling',
+        duration: '60 minutes',
+        intensity: 'Medium',
+        estimatedCalories: 500,
+        metValue: 8.5,
+        summary: 'Moderate cycling session for endurance',
+        timestamp: DateTime.now(),
+        originalInput: 'Cycling 60 mins',
+        userId: 'positive-case-user',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AnalysisResultWidget(
+              analysisResult: complete,
+              onRetry: () {},
+              onSave: () {},
+              onCorrect: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Cycling'), findsOneWidget);
+      expect(find.text('60 minutes'), findsOneWidget);
+      expect(find.text('500 kcal'), findsOneWidget);
+      expect(find.text('8.5'), findsOneWidget);
+      expect(find.text('Moderate cycling session for endurance'), findsOneWidget);
+      expect(find.text('Save Log'), findsOneWidget);
+    });
+
+      testWidgets('corner case: empty fields but considered complete', (WidgetTester tester) async {
+      final emptyComplete = ExerciseAnalysisResult(
+        exerciseType: '',
+        duration: '',
+        intensity: '',
+        estimatedCalories: 0,
+        metValue: 0.0,
+        summary: '',
+        timestamp: DateTime.now(),
+        originalInput: '',
+        userId: 'corner-case-user',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AnalysisResultWidget(
+              analysisResult: emptyComplete,
+              onRetry: () {},
+              onSave: () {},
+              onCorrect: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      // Still should render the stat rows with empty strings
+      expect(find.text(''), findsNWidgets(4)); // exerciseType, duration, intensity, summary
+      expect(find.text('Save Log'), findsOneWidget); // considered complete
+      expect(find.text('Try Again'), findsOneWidget); // still allowed
+    });
+
     // Tests for Correction Functionality
     group('Correction Functionality', () {
       testWidgets('displays correction button for complete analysis results',


### PR DESCRIPTION
This pull request includes dependency updates, test refactoring, and minor improvements to the handling and display of exercise analysis data.

---

### 🏋️ Exercise Analysis Display Fixes

* Updated the `missingInfo` key from `'type'` to `'exercise_type'` in `analysis_result_widget.dart` to match the actual API response structure.
* Adjusted the label mapping logic to ensure human-readable display of `exercise_type`, `duration`, and `intensity`.
* Updated corresponding test data in `analysis_result_widget_test.dart` to reflect the corrected key.

---

### ✅ Test Improvements

* Refactored test cases for clarity and consistency.
* Added **two new widget tests**:

  * ✔️ **Positive case**: Verifies correct display of complete analysis data including MET and summary.
  * ⚠️ **Corner case**: Ensures UI handles empty string fields gracefully while still considering the result complete.

**Screenshot Descriptions:**
1. Example output that does not contain Exercise type, duration, and intensity
<img src="https://github.com/user-attachments/assets/fce0022a-c6ca-4e95-9487-dc943d7381de" alt="Screenshot 1" width="300"/>

2. Previously, the widget showed `exercise_type` instead of `Exercise type`. I fixed it in this PR
<img src="https://github.com/user-attachments/assets/12c820ca-aa7b-487c-abea-ac01af2752a1" alt="Screenshot 2" width="300"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected label mapping in the analysis result widget to properly display missing exercise type information.

- **Tests**
  - Updated tests to reflect the corrected key for missing exercise type information.
  - Added tests for fully complete and edge-case scenarios in the analysis result widget to ensure accurate display and button availability.

- **Chores**
  - Updated Husky to version 9.1.7 and replaced the Husky hook script with a deprecation notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->