### PR TITLE
chore: repush

### DIFF
--- a/lib/features/food_database_input/presentation/widgets/selected_foods_tab.dart
+++ b/lib/features/food_database_input/presentation/widgets/selected_foods_tab.dart
@@ -132,7 +132,7 @@ class SelectedFoodsTab extends StatelessWidget {
                         },
                       ),
               ),
-
+//sigma
               const SizedBox(height: 16),
 
               // Action buttons


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc633f52-ea76-49a2-a376-00c2c0b31584)


This pull request introduces significant updates to the `FoodItemCard` component, improves how portions are handled across the app, and includes a minor enhancement to the main application configuration. Below is a summary of the most important changes grouped by theme:

### FoodItemCard Enhancements:
* Converted `FoodItemCard` from a `StatelessWidget` to a `StatefulWidget` to manage state for user inputs such as portion size and count. Added a `_FoodItemCardState` class to handle state management. [[1]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L7-R7) [[2]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L28-R68)
* Introduced a `TextEditingController` for the portion input, with validation to ensure values are between 1 and 1000 grams. Added logic to reset invalid inputs to the last valid value.
* Updated UI elements to use `widget` properties for dynamic rendering, such as `widget.food`, `widget.primaryGreen`, and `widget.primaryPink`. [[1]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L58-R91) [[2]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L72-R102) [[3]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L93-R122) [[4]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L110-R141)
* Replaced the slider for portion selection with a text input field for better precision. Added helper text to guide users on valid input ranges. [[1]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L121-R260) [[2]](diffhunk://#diff-7af5fe4dfad19d4e0f51f4fe852d7e76f040c9205fd5424e652c13eb196573b7L190-L267)

### Portion Handling Improvements:
* Standardized the initial portion value to always default to 100.0 grams when adding a new food item. Removed logic that depended on ingredient servings. [[1]](diffhunk://#diff-021b4c67afb831bb4688e669ef774d5b563df54a22dee51fadf6f4e8f0e4b9ddL86-R89) [[2]](diffhunk://#diff-d084942f9c7e4313610d7c119beb49023af503500706daed5d2f69d8921f58ddL118-R120)

### Application Configuration:
* Disabled the debug banner in the `MaterialApp` configuration for a cleaner UI in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Portion size for food items can now be edited directly in the interface using an input field, allowing users to specify values between 1 and 1000 grams.
  - Helper text guides users on valid portion size entry.

- **Improvements**
  - Default portion size is now consistently set to 100 grams for all new food selections.
  - Updated layout for food item cards, providing clearer and more consistent input fields for both count and portion size.
  - The debug banner is now hidden during development for a cleaner app appearance.

- **Bug Fixes**
  - Improved validation for portion size input to prevent invalid entries.

- **Chores**
  - Removed comprehensive widget tests for the selected foods tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
This pull request makes a minor change to the `SelectedFoodsTab` widget in the `lib/features/food_database_input/presentation/widgets/selected_foods_tab.dart` file. It adds a comment labeled `//sigma` for clarification or annotation purposes.